### PR TITLE
Changed sourceforge download links to github

### DIFF
--- a/source/getting_started.rst
+++ b/source/getting_started.rst
@@ -9,7 +9,7 @@ Installation
 
 There is a single click installer that installs MsysGit, Kdiff3 and Git Extensions. The installer will detect 
 if 32bit and/or 64bit versions should be installed.
-The installer can be found `here <http://sourceforge.net/projects/gitextensions/>`_.
+The installer can be found `here <https://github.com/gitextensions/gitextensions/releases/latest>`_.
 
 .. image:: /images/install/install1.png
 
@@ -61,7 +61,7 @@ First, make sure you have the latest mono version on your Mac. This section will
         LLVM:          yes(2.9svn-mono)
         GC:            Included Boehm (with typed GC)
 
-6) Now download Git Extensions latest version from https://sourceforge.net/projects/gitextensions. Remember to select the appropriate package otherwise you could have problems.
+6) Now download Git Extensions latest version from https://github.com/gitextensions/gitextensions/releases/latest. Remember to select the appropriate package otherwise you could have problems.
 7) Browse into the folder where you extracted the package and just run mono command, like the example below::
 
     $ mono GitExtensions.exe 


### PR DESCRIPTION
Changed the 2 instances of sourceforge download page links to https://github.com/gitextensions/gitextensions/releases/latest