### PR TITLE
 Updated links to git-scm.com

### DIFF
--- a/source/settings.rst
+++ b/source/settings.rst
@@ -791,7 +791,7 @@ depending on whether or not they are distributed with that repository.
 
         If enabled, then in addition to branch names, git will populate the log message with one-line descriptions
         from at most the given number actual commits that are being merged.
-        See https://git-scm.com/docs/git-merge#git-merge---logltngt
+        See https://git-scm.com/docs/git-merge#Documentation/git-merge.txt---logltngt
 
     .. settingspage:: Browse repository window
 
@@ -899,7 +899,7 @@ depending on whether or not they are distributed with that repository.
 
       .. setting:: Omit uninteresting changes from combined diff
 
-        Includes git `--cc` switch when generating a diff. See https://git-scm.com/docs/git-diff-tree#git-diff-tree---cc
+        Includes git `--cc` switch when generating a diff. See https://git-scm.com/docs/git-diff-tree#Documentation/git-diff-tree.txt---cc
 
       .. setting:: Open Submodule Diff in separate window
 


### PR DESCRIPTION
Follow-up of [gitextensions PR #6428](https://github.com/gitextensions/gitextensions/pull/6428)

- [git-scm.com](https://www.git-scm.com) recently changed the structure of the HTML anchors in the git reference manual. These are used to link directly to specific options of git commands.
GE has a few of those links in code comments, which still linked to the correct page (i.e. git command), but no longer to the correct section (i.e. option). For example:
  - old: https://git-scm.com/docs/git-merge#git-merge---logltngt
  - new: https://git-scm.com/docs/git-merge#Documentation/git-merge.txt---logltngt